### PR TITLE
Change useEffect containing GET request to only run on initial render

### DIFF
--- a/src/AddMenuItem/AddMenuItem.js
+++ b/src/AddMenuItem/AddMenuItem.js
@@ -94,13 +94,11 @@ export default function AddMenuItem({ adminSelections, restaurants }) {
   }
 
   useEffect(() => {
-    if (images) return
     getData('https://menu-ify-be.herokuapp.com/api/v1/restaurants')
       .then(data => {
         setImages(data)
       })
-
-  })
+  }, [])
 
   useEffect(() => {
     if (!images) {


### PR DESCRIPTION
#### What does this PR do?
`AddMenuItem` used conditional logic to determine whether or not to fetch the search images data. This seemed error prone and might be causing some testing issues within Cypress, which is logging several fetch requests where there should only be one (or potentially two, since React strict mode invokes useEffect twice in dev mode?).

#### Where should your reviewer start
Only one change so check the commit.

#### What (if any) features are you implementing

#### What (if anything) did you refactor?
Fetch request in `AddMenuItem`

#### Were there any issues that arose?

#### Is there anything that you need from your teammate?

#### Any other comments, questions, or concerns?
I kept the two useEffect hooks separate because we want our fetch to only run on the initial page load. If I roll it in with our second useEffect which updates search results to match the searchbar input text we'll end up having to rely on the same conditional logic that I wanted to refactor out here. I used the empty array dependency to run our fetch useEffect hook only on the initial page render, I think this is the best solution to narrow down exactly where the issue is.